### PR TITLE
Fixing call to group() failing program when asset_id_re.search(url) returns None

### DIFF
--- a/main.py
+++ b/main.py
@@ -584,9 +584,13 @@ class Udemy:
         temp_path.mkdir(parents=True, exist_ok=True)
 
         # # extract the asset id from the url
-        asset_id = asset_id_re.search(url).group("id")
-
-        m3u8_path = Path(temp_path, f"index_{asset_id}.m3u8")
+        search = asset_id_re.search(url)
+        if search is not None and len(search.groups()) > 0:
+            asset_id = search.group("id")
+            m3u8_path = Path(temp_path, f"index_{asset_id}.m3u8")
+        else:
+            logger.error(f"Unable to parse the asset ID from m3u8 url: {url}")
+            return _temp
 
         try:
             r = self.session._get(url)


### PR DESCRIPTION
This was failing program when the `url` passed to `_extract_m3u8()` is something that doesn't contain `.../asset/<id>/...` in the URL.
For example, it would fail for this URL: 
```txt
[11:20:12] [udemy-downloader] [_extract_m3u8:592] ERROR: Unable to parse the asset ID from m3u8 url: https://mp4-c.udemycdn.com/2021-10-14_16-17-15-d0950d9e1b5ef076b9519c68db1f82e5/2/WebHD.mp4?Expires=1703286396&Signature=<REDACTED_HASH>&Key-Pair-Id=<REDACTED>
```